### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-java@v3.11.0
+      - uses: actions/setup-java@v3.12.0
         with:
           distribution: "zulu"
           java-version: "17"
@@ -50,7 +50,7 @@ jobs:
           cp -f build.md build.tmp
 
       - name: Upload modules to release
-        uses: svenstaro/upload-release-action@2.6.1
+        uses: svenstaro/upload-release-action@2.7.0
         with:
           body: ${{ steps.get_output.outputs.BUILD_LOG }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-update.yml
+++ b/.github/workflows/github-actions-update.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.12.0](https://github.com/actions/setup-java/releases/tag/v3.12.0)** on 2023-07-24T11:31:29Z
* **[svenstaro/upload-release-action](https://github.com/svenstaro/upload-release-action)** published a new release **[2.7.0](https://github.com/svenstaro/upload-release-action/releases/tag/2.7.0)** on 2023-07-28T16:39:05Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
