### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,13 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-java@v3.11.0
+      - uses: actions/setup-java@v3.12.0
         with:
           distribution: "zulu"
           java-version: "17"
 
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
           submodules: true
@@ -50,7 +50,7 @@ jobs:
           cp -f build.md build.tmp
 
       - name: Upload modules to release
-        uses: svenstaro/upload-release-action@2.6.1
+        uses: svenstaro/upload-release-action@2.7.0
         with:
           body: ${{ steps.get_output.outputs.BUILD_LOG }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
           POST="https://api.telegram.org/bot${TG_TOKEN}/sendMessage"
           curl -X POST --data-urlencode "parse_mode=Markdown" --data-urlencode "text=${MSG}" --data-urlencode "chat_id=${TG_CHAT}" "$POST"
 
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v3.1.3
         with:
           name: logs
           path: logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/github-actions-update.yml
+++ b/.github/workflows/github-actions-update.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[svenstaro/upload-release-action](https://github.com/svenstaro/upload-release-action)** published a new release **[2.7.0](https://github.com/svenstaro/upload-release-action/releases/tag/2.7.0)** on 2023-07-28T16:39:05Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.12.0](https://github.com/actions/setup-java/releases/tag/v3.12.0)** on 2023-07-24T11:31:29Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.3](https://github.com/actions/upload-artifact/releases/tag/v3.1.3)** on 2023-09-06T19:16:46Z
